### PR TITLE
Initial validation tests

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -103,7 +103,7 @@ foreach (example activityset-testany activityset-waitany activityset-waitall act
                  cloud-capping cloud-migration cloud-simple
                  dag-comm dag-from-json-simple dag-from-dax-simple dag-from-dax dag-from-dot-simple dag-from-dot dag-failure dag-io dag-scheduling dag-simple dag-tuto
                  dht-chord dht-kademlia
-                 energy-exec energy-boot energy-link energy-vm energy-exec-ptask energy-wifi
+                 energy-exec energy-boot energy-link energy-vm energy-exec-ptask energy-wifi exec-co2
                  engine-filtering engine-run-partial
                  exec-async exec-basic exec-dvfs exec-remote exec-suspend exec-waitfor exec-dependent exec-unassigned
                  exec-ptask-multicore exec-ptask-multicore-latency exec-cpu-nonlinear exec-cpu-factors exec-failure exec-threads

--- a/examples/cpp/exec-co2/s4u-exec-co2.cpp
+++ b/examples/cpp/exec-co2/s4u-exec-co2.cpp
@@ -1,0 +1,165 @@
+/* Copyright (c) 2007-2024. The SimGrid Team. All rights reserved.          */
+
+/* This program is free software; you can redistribute it and/or modify it
+ * under the terms of the license (GNU LGPL) which comes with this package. */
+
+#include "simgrid/s4u.hpp"
+#include "simgrid/plugins/energy.h"
+#include "simgrid/plugins/carbon_footprint.h"
+
+XBT_LOG_NEW_DEFAULT_CATEGORY(s4u_test, "Messages specific for this s4u example");
+namespace sg4 = simgrid::s4u;
+
+
+void turn_host_off(simgrid::s4u::Host * host)
+{
+  host->turn_off();
+}
+void update_co2_actor(simgrid::s4u::Host* host, std::map<int, double > co2_data)
+{  
+  for (auto it = co2_data.begin(); it != co2_data.end(); it++)
+  {
+    int time = it->first;
+    double co2_data = it->second;
+    simgrid::s4u::this_actor::sleep_until(time);
+    sg_host_set_carbon_intensity(host,co2_data);    
+  }      
+}
+
+void test_execution()
+{          
+    sg4::Host* host = sg4::this_actor::get_host();
+    
+    double host_speed_in_flops = host->get_speed();
+
+    // Run one task (total 1 CPU core) for 1 hour    
+    double flopAmount_1_hour = host_speed_in_flops * 3600 * 1;    
+    
+    sg4::ExecPtr activity = sg4::this_actor::exec_init(flopAmount_1_hour);
+    activity->start();
+    activity->wait();
+
+    // Run two tasks (total of 2 CPU cores) for 2 hours
+    sg4::ExecPtr activity_2_1 = sg4::this_actor::exec_init(flopAmount_1_hour*2);        
+    sg4::ExecPtr activity_2_2 = sg4::this_actor::exec_init(flopAmount_1_hour*2);
+    
+    activity_2_1->start();
+    activity_2_2->start();
+
+    activity_2_1->wait();
+    activity_2_2->wait();
+  
+    // Run three tasks (total of 3 CPU cores) for 3 hours
+    sg4::ExecPtr activity_3_1 = sg4::this_actor::exec_init(flopAmount_1_hour*3);        
+    sg4::ExecPtr activity_3_2 = sg4::this_actor::exec_init(flopAmount_1_hour*3);
+    sg4::ExecPtr activity_3_3 = sg4::this_actor::exec_init(flopAmount_1_hour*3);
+    
+    activity_3_1->start();
+    activity_3_2->start();
+    activity_3_3->start();
+
+    activity_3_1->wait();
+    activity_3_2->wait();
+    activity_3_3->wait();
+
+    // Run four tasks (total of 4 CPU cores) for 4 hours
+    sg4::ExecPtr activity_4_1 = sg4::this_actor::exec_init(flopAmount_1_hour*4);        
+    sg4::ExecPtr activity_4_2 = sg4::this_actor::exec_init(flopAmount_1_hour*4);
+    sg4::ExecPtr activity_4_3 = sg4::this_actor::exec_init(flopAmount_1_hour*4);        
+    sg4::ExecPtr activity_4_4 = sg4::this_actor::exec_init(flopAmount_1_hour*4);
+
+    activity_4_1->start();
+    activity_4_2->start();
+    activity_4_3->start();
+    activity_4_4->start();
+
+    activity_4_1->wait();
+    activity_4_2->wait();
+    activity_4_3->wait();
+    activity_4_4->wait();
+
+    
+ 
+}
+
+int main(int argc, char* argv[])
+{
+
+
+  // Dict values for grid CO2 of each scenario, key is the time, and value is the carbon emissions (in g CO2/kWh)
+  std::map<int, double > brazil_grid_co2;
+  std::map<int, double> france_grid_co2;
+  std::map<int, double > usa_grid_co2;
+
+  int seconds_in_hour = 3600;
+
+  // Grid electricity emissions values
+
+  // For Brazil    
+  brazil_grid_co2[0] = 100.07;  
+  brazil_grid_co2[seconds_in_hour*1] = 93.6;
+  brazil_grid_co2[seconds_in_hour*2] = 93.89;
+  brazil_grid_co2[seconds_in_hour*3] = 96.04;
+  brazil_grid_co2[seconds_in_hour*4] = 95.0;
+  brazil_grid_co2[seconds_in_hour*5] = 94.4;
+  brazil_grid_co2[seconds_in_hour*6] = 94.11;
+  brazil_grid_co2[seconds_in_hour*7] = 94.99;
+  brazil_grid_co2[seconds_in_hour*8] = 96.44;
+  brazil_grid_co2[seconds_in_hour*9] = 99.76;
+
+
+  // For France
+  france_grid_co2[0] = 29.09;
+  france_grid_co2[seconds_in_hour*1] = 30.08;
+  france_grid_co2[seconds_in_hour*2] = 32.33;
+  france_grid_co2[seconds_in_hour*3] = 32.96;
+  france_grid_co2[seconds_in_hour*4] = 33.0;
+  france_grid_co2[seconds_in_hour*5] = 33.41;
+  france_grid_co2[seconds_in_hour*6] = 34.52;
+  france_grid_co2[seconds_in_hour*7] = 33.63;
+  france_grid_co2[seconds_in_hour*8] = 32.17;
+  france_grid_co2[seconds_in_hour*9] = 31.95;
+
+  // For USA
+  usa_grid_co2[0] = 453.54;
+  usa_grid_co2[seconds_in_hour*1] = 441.48;
+  usa_grid_co2[seconds_in_hour*2] = 437.93;
+  usa_grid_co2[seconds_in_hour*3] = 437.61;
+  usa_grid_co2[seconds_in_hour*4] = 442.29;
+  usa_grid_co2[seconds_in_hour*5] = 447.18;
+  usa_grid_co2[seconds_in_hour*6] = 452.04;
+  usa_grid_co2[seconds_in_hour*7] = 453.96;
+  usa_grid_co2[seconds_in_hour*8] = 455.13;
+  usa_grid_co2[seconds_in_hour*9] = 457.54;
+
+  sg_host_energy_plugin_init();              
+  sg_host_carbon_footprint_plugin_init();
+
+  sg4::Engine e(&argc, argv);
+  e.load_platform(argv[1]);
+  
+  sg4::Host* host_br_static_co2 = sg4::Host::by_name("host_br_static_co2");
+  sg4::Host* host_fr_static_co2 = sg4::Host::by_name("host_fr_static_co2");
+  sg4::Host* host_usa_static_co2 = sg4::Host::by_name("host_usa_static_co2"); 
+
+  sg4::Host* host_br_dynamic_co2 = sg4::Host::by_name("host_br_dynamic_co2");
+  sg4::Host* host_fr_dynamic_co2 = sg4::Host::by_name("host_fr_dynamic_co2");
+  sg4::Host* host_usa_dynamic_co2 = sg4::Host::by_name("host_usa_dynamic_co2");
+
+
+  sg4::Actor::create("turn_off test", host_br_static_co2, turn_host_off,host_usa_static_co2);
+  sg4::Actor::create("turn_off test", host_br_static_co2, turn_host_off,host_usa_dynamic_co2);
+       
+  sg4::Actor::create("execution", host_br_static_co2, test_execution);
+  sg4::Actor::create("execution", host_br_dynamic_co2, test_execution);
+
+  sg4::Actor::create("update_co2", host_br_static_co2, update_co2_actor,host_usa_dynamic_co2,usa_grid_co2);
+  sg4::Actor::create("update_co2", host_br_static_co2, update_co2_actor,host_fr_dynamic_co2,france_grid_co2);
+  sg4::Actor::create("update_co2", host_br_static_co2, update_co2_actor,host_br_dynamic_co2,brazil_grid_co2);
+
+  e.run();
+
+
+  return 0;
+
+}

--- a/examples/cpp/exec-co2/s4u-exec-co2.tesh
+++ b/examples/cpp/exec-co2/s4u-exec-co2.tesh
@@ -1,0 +1,18 @@
+#!/usr/bin/env tesh
+
+p Testing the mechanism for computing host emissions
+
+$ ${bindir:=.}/s4u-exec-co2 ${platfdir}/emission_platform.xml
+> [36000.000000] [host_energy/INFO] Total energy consumption: 20160000.000000 Joules (used hosts: 12600000.000000 Joules; unused/idle hosts: 7560000.000000)
+> [36000.000000] [host_energy/INFO] Energy consumption of host host_br_dynamic_co2: 6300000.000000 Joules
+> [36000.000000] [host_carbon_footprint/INFO] Carbon emitted by host host_br_dynamic_co2: 167.644250 g
+> [36000.000000] [host_energy/INFO] Energy consumption of host host_br_static_co2: 6300000.000000 Joules
+> [36000.000000] [host_carbon_footprint/INFO] Carbon emitted by host host_br_static_co2: 160.090000 g
+> [36000.000000] [host_energy/INFO] Energy consumption of host host_fr_dynamic_co2: 3600000.000000 Joules
+> [36000.000000] [host_carbon_footprint/INFO] Carbon emitted by host host_fr_dynamic_co2: 32.314000 g
+> [36000.000000] [host_energy/INFO] Energy consumption of host host_fr_static_co2: 3600000.000000 Joules
+> [36000.000000] [host_carbon_footprint/INFO] Carbon emitted by host host_fr_static_co2: 33.450000 g
+> [36000.000000] [host_energy/INFO] Energy consumption of host host_usa_dynamic_co2: 180000.000000 Joules
+> [36000.000000] [host_carbon_footprint/INFO] Carbon emitted by host host_usa_dynamic_co2: 22.393500 g
+> [36000.000000] [host_energy/INFO] Energy consumption of host host_usa_static_co2: 180000.000000 Joules
+> [36000.000000] [host_carbon_footprint/INFO] Carbon emitted by host host_usa_static_co2: 20.182500 g

--- a/examples/cpp/exec-co2/validation.md
+++ b/examples/cpp/exec-co2/validation.md
@@ -1,0 +1,157 @@
+# Validation of the SimGrid CO2 emissions plugin
+
+This document describes how we validated our plugin to compute the emissions from electricity consumption of machines in SimGrid. We consider static and dynamic values for the input static of grid electricity emissions values (to represent for instance the variability caused by using intermittent renewable sources), and we validate for the following scenarios:
+
+- Machines off;
+- Machines idle;
+- Performing computations
+---
+
+## Inputs
+We use homogeneous machines with the following hardware properties: 
+
+| CPU cores used | Power (W) |
+|------------------|-----------|
+| 1 core           | 125 W     |
+| 2 cores          | 150 W     |
+| 3 cores          | 175 W     |
+| 4 cores          | 200 W     |
+
+| State | Power (W) |
+|-------|-----------|
+| Idle  | 100 W     |
+| Off   | 5 W       |
+
+**Note:** Our plugin extends SimGrid’s energy plugin, which has been validated on both homogeneous and heterogeneous platforms. Although the scenarios below consider only homogeneous machines, the plugin also supports heterogeneous machines.
+
+---
+## Carbon-Intensity Data
+
+We consider three grid locations, and use data provided by [ElectricityMap](https://www.electricitymaps.com/) data:
+
+- **USA** —    higher carbon intensity, low share of renewable sources in the electricity grid.
+- **Brazil** — intermediate carbon intensity, has a presence of renewables, such as hydroelectric power
+- **France** — lower carbon intensity, due to nuclear power
+
+
+---
+# Validation scenarios
+
+All scenarios use a **10‑hour time horizon**.
+
+---
+
+# 1. Static CO₂ Scenarios
+
+## 1.1 Machine Off (USA grid, carbon intensity = 403.65 gCO2/kWh)
+
+- E_J = 5 W  (power when off) * 3600 (seconds in one hour) * 10 (hours in the time horizon) = 180000  J
+- E_kWh = 180000 / 3600000 = 0.05 kWh
+
+- **Expected emissions:**  0.05 * 403.65 = **20.1825 g** CO2
+
+---
+
+## 1.2 Machine Idle (France grid, carbon intensity = 33.45 gCO2/kWh
+
+- Power idle = 100 W
+- E_J = 100 * 3600 * 10 = 3600000 J
+- E_kWh = 1.0 kWh
+- **Expected emissions:** 1.0 * 33.45 = **33.45 gCO2**
+
+---
+
+## 1.3 Machine Running Tasks (Brazil grid, carbon intensity = 91.48 gCO2/kWh)
+
+We evaluate running tasks using all the cores in the machine in the following 4 scenarios:
+- A : running computations using 1 CPU core for 1 hour
+- B : running computations using 2 CPU cores for 2 hours
+- C : running computations using 3 CPU cores for 3 hours
+- D : running computations using 4 CPU cores for 4 hours
+
+| Scenarios | Cores | Power (W) | Duration (h) | Energy (kWh) | CO₂ (g) |
+|---------|-------|-----------|--------------|--------------|---------|
+| A       | 1     | 125       | 1            | 0.125        | 11.435  |
+| B       | 2     | 150       | 2            | 0.300        | 27.444  |
+| C       | 3     | 175       | 3            | 0.525        | 48.027  |
+| D       | 4     | 200       | 4            | 0.800        | 73.184  |
+| **Total** | —   | —         | 10           | **1.750**    | **160.09** |
+
+
+---
+
+# 2. Dynamic CO2 Scenarios
+
+In these scenarios, the carbon intensity varies hourly.
+
+---
+
+## 2.1 Machine Off — using hourly carbon intensity from USA 
+
+Power = 5 W  = 0.005 kWh/hour.
+
+| Hour | CI (gCO₂/kWh) | Energy (kWh) | Hourly CO₂ (g) |
+|-----:|--------------:|-------------:|---------------:|
+| 1 | 453.54 | 0.005 | 2.2677 |
+| 2 | 441.48 | 0.005 | 2.2074 |
+| 3 | 437.93 | 0.005 | 2.1897 |
+| 4 | 437.61 | 0.005 | 2.1881 |
+| 5 | 442.29 | 0.005 | 2.2115 |
+| 6 | 447.18 | 0.005 | 2.2359 |
+| 7 | 452.04 | 0.005 | 2.2602 |
+| 8 | 453.96 | 0.005 | 2.2698 |
+| 9 | 455.13 | 0.005 | 2.2757 |
+| 10 | 457.54 | 0.005 | 2.2877 |
+| **Total** | — | **0.05** | **22.3935 gCO₂** |
+
+---
+
+## 2.2 Machine Idle — using hourly carbon intensity from France 
+
+Power = 100 W = 0.1 kWh/hour.
+
+| Hour | CI (gCO₂/kWh) | Energy (kWh) | Hourly CO₂ (g) |
+|-----:|--------------:|-------------:|---------------:|
+| 1 | 29.09 | 0.1 | 2.909 |
+| 2 | 30.08 | 0.1 | 3.008 |
+| 3 | 32.33 | 0.1 | 3.233 |
+| 4 | 32.96 | 0.1 | 3.296 |
+| 5 | 33.00 | 0.1 | 3.300 |
+| 6 | 33.41 | 0.1 | 3.341 |
+| 7 | 34.52 | 0.1 | 3.452 |
+| 8 | 33.63 | 0.1 | 3.363 |
+| 9 | 32.17 | 0.1 | 3.217 |
+| 10 | 31.95 | 0.1 | 3.195 |
+| **Total** | — | **1.0** | **32.314 gCO₂** |
+
+---
+
+## 2.3 Machine Running Tasks — using hourly carbon intensity from  Brazil 
+
+Power consumption varies by active core count (same as Section 1.3).
+
+### Hourly Carbon Intensities
+| Hour | CI (gCO₂/kWh) |
+|-----:|--------------:|
+| 1 | 100.07 |
+| 2 | 93.60 |
+| 3 | 93.89 |
+| 4 | 96.04 |
+| 5 | 95.00 |
+| 6 | 94.40 |
+| 7 | 94.11 |
+| 8 | 94.99 |
+| 9 | 96.44 |
+| 10 | 99.76 |
+
+### Energy & Emissions by Task Segment
+
+| Scenarios | Cores | Hours Covered | Power (W) | Energy (kWh/hour)  | CO₂ (g) Calc |
+|---------|-------|---------------|-----------|-------------------|---------------|
+| A | 1 | 1 | 125 | 0.125 | 0.125 × 100.07 = 12.50875 |
+| B | 2 | 2, 3| 150 | 0.150 | 0.15 × (93.60 + 93.89) = 28.12350 |
+| C | 3 | 4, 5, 6  | 175 | 0.175 |  0.175 × (96.04 + 95.00 + 94.40) = 49.95200 |
+| D | 4 | 7, 8, 9, 10| 200 | 0.200 |  0.20 × (94.11 + 94.99 + 96.44 + 99.76) = 77.06000 |
+| **Total** | — | 10 h | — | **1.750 kWh** |  **167.64425 gCO₂** |
+
+---

--- a/examples/platforms/emission_platform.xml
+++ b/examples/platforms/emission_platform.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE platform SYSTEM "https://simgrid.org/simgrid.dtd">
+<platform version="4.1">
+  <zone id="AS0" routing="Full">          
+    <host core="4" id="host_br_static_co2" pstate="0" speed="100.0Mf">
+      <prop id="wattage_per_state" value="100.0:100:200.0" />
+      <prop id="wattage_off" value="5" />
+      <prop id="carbon_intensity" value="91.48" />
+    </host>
+
+    <host core="4" id="host_fr_static_co2" pstate="0" speed="100.0Mf">      
+      <prop id="wattage_per_state" value="100.0:100:200.0" />
+      <prop id="wattage_off" value="5" />
+      <prop id="carbon_intensity" value="33.45" />
+    </host>
+
+    <host core="4" id="host_usa_static_co2" pstate="0" speed="100.0Mf">      
+      <prop id="wattage_per_state" value="100.0:100:200.0" />
+      <prop id="wattage_off" value="5" />
+      <prop id="carbon_intensity" value="403.65" />
+    </host>
+
+    <host core="4" id="host_br_dynamic_co2" pstate="0" speed="100.0Mf">
+      <prop id="wattage_per_state" value="100.0:100:200.0" />
+      <prop id="wattage_off" value="5" />
+      <prop id="carbon_intensity" value="91.48" />
+    </host>
+
+    <host core="4" id="host_fr_dynamic_co2" pstate="0" speed="100.0Mf">      
+      <prop id="wattage_per_state" value="100.0:100:200.0" />
+      <prop id="wattage_off" value="5" />
+      <prop id="carbon_intensity" value="33.45" />
+    </host>
+
+    <host core="4" id="host_usa_dynamic_co2" pstate="0" speed="100.0Mf">      
+      <prop id="wattage_per_state" value="100.0:100:200.0" />
+      <prop id="wattage_off" value="5" />
+      <prop id="carbon_intensity" value="403.65" />
+    </host>
+
+  </zone>
+
+</platform>


### PR DESCRIPTION
# Validation of the SimGrid CO2 emissions plugin

This document describes how we validated our plugin to compute the emissions from electricity consumption of machines in SimGrid. We consider static and dynamic values for the input static of grid electricity emissions values (to represent for instance the variability caused by using intermittent renewable sources), and we validate for the following scenarios:

- Machines off;
- Machines idle;
- Performing computations
---

## Inputs
We use homogeneous machines with the following hardware properties: 

| CPU cores used | Power (W) |
|------------------|-----------|
| 1 core           | 125 W     |
| 2 cores          | 150 W     |
| 3 cores          | 175 W     |
| 4 cores          | 200 W     |

| State | Power (W) |
|-------|-----------|
| Idle  | 100 W     |
| Off   | 5 W       |

**Note:** Our plugin extends SimGrid’s energy plugin, which has been validated on both homogeneous and heterogeneous platforms. Although the scenarios below consider only homogeneous machines, the plugin also supports heterogeneous machines.

---
## Carbon-Intensity Data

We consider three grid locations, and use data provided by [ElectricityMap](https://www.electricitymaps.com/) data:

- **USA** —    higher carbon intensity, low share of renewable sources in the electricity grid.
- **Brazil** — intermediate carbon intensity, has a presence of renewables, such as hydroelectric power
- **France** — lower carbon intensity, due to nuclear power


---
# Validation scenarios

All scenarios use a **10‑hour time horizon**.

---

# 1. Static CO₂ Scenarios

## 1.1 Machine Off (USA grid, carbon intensity = 403.65 gCO2/kWh)

- E_J = 5 W  (power when off) * 3600 (seconds in one hour) * 10 (hours in the time horizon) = 180000  J
- E_kWh = 180000 / 3600000 = 0.05 kWh

- **Expected emissions:**  0.05 * 403.65 = **20.1825 g** CO2

---

## 1.2 Machine Idle (France grid, carbon intensity = 33.45 gCO2/kWh

- Power idle = 100 W
- E_J = 100 * 3600 * 10 = 3600000 J
- E_kWh = 1.0 kWh
- **Expected emissions:** 1.0 * 33.45 = **33.45 gCO2**

---

## 1.3 Machine Running Tasks (Brazil grid, carbon intensity = 91.48 gCO2/kWh)

We evaluate running tasks using all the cores in the machine in the following 4 scenarios:
- A : running computations using 1 CPU core for 1 hour
- B : running computations using 2 CPU cores for 2 hours
- C : running computations using 3 CPU cores for 3 hours
- D : running computations using 4 CPU cores for 4 hours

| Scenarios | Cores | Power (W) | Duration (h) | Energy (kWh) | CO₂ (g) |
|---------|-------|-----------|--------------|--------------|---------|
| A       | 1     | 125       | 1            | 0.125        | 11.435  |
| B       | 2     | 150       | 2            | 0.300        | 27.444  |
| C       | 3     | 175       | 3            | 0.525        | 48.027  |
| D       | 4     | 200       | 4            | 0.800        | 73.184  |
| **Total** | —   | —         | 10           | **1.750**    | **160.09** |


---

# 2. Dynamic CO2 Scenarios

In these scenarios, the carbon intensity varies hourly.

---

## 2.1 Machine Off — using hourly carbon intensity from USA 

Power = 5 W  = 0.005 kWh/hour.

| Hour | CI (gCO₂/kWh) | Energy (kWh) | Hourly CO₂ (g) |
|-----:|--------------:|-------------:|---------------:|
| 1 | 453.54 | 0.005 | 2.2677 |
| 2 | 441.48 | 0.005 | 2.2074 |
| 3 | 437.93 | 0.005 | 2.1897 |
| 4 | 437.61 | 0.005 | 2.1881 |
| 5 | 442.29 | 0.005 | 2.2115 |
| 6 | 447.18 | 0.005 | 2.2359 |
| 7 | 452.04 | 0.005 | 2.2602 |
| 8 | 453.96 | 0.005 | 2.2698 |
| 9 | 455.13 | 0.005 | 2.2757 |
| 10 | 457.54 | 0.005 | 2.2877 |
| **Total** | — | **0.05** | **22.3935 gCO₂** |

---

## 2.2 Machine Idle — using hourly carbon intensity from France 

Power = 100 W = 0.1 kWh/hour.

| Hour | CI (gCO₂/kWh) | Energy (kWh) | Hourly CO₂ (g) |
|-----:|--------------:|-------------:|---------------:|
| 1 | 29.09 | 0.1 | 2.909 |
| 2 | 30.08 | 0.1 | 3.008 |
| 3 | 32.33 | 0.1 | 3.233 |
| 4 | 32.96 | 0.1 | 3.296 |
| 5 | 33.00 | 0.1 | 3.300 |
| 6 | 33.41 | 0.1 | 3.341 |
| 7 | 34.52 | 0.1 | 3.452 |
| 8 | 33.63 | 0.1 | 3.363 |
| 9 | 32.17 | 0.1 | 3.217 |
| 10 | 31.95 | 0.1 | 3.195 |
| **Total** | — | **1.0** | **32.314 gCO₂** |

---

## 2.3 Machine Running Tasks — using hourly carbon intensity from  Brazil 

Power consumption varies by active core count (same as Section 1.3).

### Hourly Carbon Intensities
| Hour | CI (gCO₂/kWh) |
|-----:|--------------:|
| 1 | 100.07 |
| 2 | 93.60 |
| 3 | 93.89 |
| 4 | 96.04 |
| 5 | 95.00 |
| 6 | 94.40 |
| 7 | 94.11 |
| 8 | 94.99 |
| 9 | 96.44 |
| 10 | 99.76 |

### Energy & Emissions by Task Segment

| Scenarios | Cores | Hours Covered | Power (W) | Energy (kWh/hour)  | CO₂ (g) Calc |
|---------|-------|---------------|-----------|-------------------|---------------|
| A | 1 | 1 | 125 | 0.125 | 0.125 × 100.07 = 12.50875 |
| B | 2 | 2, 3| 150 | 0.150 | 0.15 × (93.60 + 93.89) = 28.12350 |
| C | 3 | 4, 5, 6  | 175 | 0.175 |  0.175 × (96.04 + 95.00 + 94.40) = 49.95200 |
| D | 4 | 7, 8, 9, 10| 200 | 0.200 |  0.20 × (94.11 + 94.99 + 96.44 + 99.76) = 77.06000 |
| **Total** | — | 10 h | — | **1.750 kWh** |  **167.64425 gCO₂** |

---